### PR TITLE
fix mac compile error and fix video path parse error

### DIFF
--- a/goldendict.pro
+++ b/goldendict.pro
@@ -206,6 +206,9 @@ mac {
     }
     INCLUDEPATH = $${PWD}/maclibs/include
     LIBS += -L$${PWD}/maclibs/lib -framework AppKit -framework Carbon
+    LIBS += -lz
+    LIBS += -llzo2
+    LIBS += -lbz2
     OBJECTIVE_SOURCES += lionsupport.mm \
                          machotkeywrapper.mm \
                          macmouseover.mm \

--- a/mdx.cc
+++ b/mdx.cc
@@ -294,16 +294,15 @@ private:
   {
       if(cacheDir==nullptr)
           cacheDir = new QTemporaryDir(QDir::temp().absolutePath() + QDir::separator() + QString::fromStdString(getId()));
+      const QString tdPath = cacheDir->path();
       const QString ltFile = cacheDir->filePath(filename).replace("\\", "/");
-      if(filename.contains("/"))
-      {
-          QString filenameDir = filename.left(filename.lastIndexOf("/"));
-          QDir dir(cacheDir->path());
-          dir.mkpath(filenameDir);
-      }
-
       if(!QFile::exists(ltFile))
       {
+          const int lSep = ltFile.lastIndexOf("/");
+          if(lSep > tdPath.length())
+          {
+              QDir(tdPath).mkpath(filename.left(lSep - tdPath.length()));
+          }
           QFile ftP(ltFile);
           if(ftP.open(QFile::WriteOnly))
           {

--- a/mdx.cc
+++ b/mdx.cc
@@ -295,6 +295,13 @@ private:
       if(cacheDir==nullptr)
           cacheDir = new QTemporaryDir(QDir::temp().absolutePath() + QDir::separator() + QString::fromStdString(getId()));
       const QString ltFile = cacheDir->filePath(filename).replace("\\", "/");
+      if(filename.contains("/"))
+      {
+          QString filenameDir = filename.left(filename.lastIndexOf("/"));
+          QDir dir(cacheDir->path());
+          dir.mkpath(filenameDir);
+      }
+
       if(!QFile::exists(ltFile))
       {
           QFile ftP(ltFile);


### PR DESCRIPTION
fix mac compile error.
In some case, the path of video in mdx files may be contain directory, it will be effect creating temporary files in Mac.